### PR TITLE
Refactor OAuth2 configuration to support multiple audiences

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,4 +55,43 @@ mvn clean install
 ### Purpose
 
 This is an enterprise-grade microservice for managing transportation provider metadata in Entur's ecosystem.
+
+## Recent Changes
+
+### OAuth2 Multi-Audience Support (2025-11-25)
+
+Refactored OAuth2 configuration to support multiple audiences following the same pattern as kilili:
+
+**Changes Made:**
+- Updated `OAuth2Config.java` to use plural audience methods (`withEnturInternalAuth0Audiences`, `withEnturPartnerAuth0Audiences`)
+- Added helper methods `parseAudiences()` and `parseFirstAudience()` to parse comma-separated audience values
+- Updated helm configuration templates to use separate audience values for each tenant
+- Modified environment-specific values files (dev/tst/prd) to include separate audience configurations
+
+**Configuration:**
+- Entur Internal and Entur Partner tenants now support multiple comma-separated audiences
+- RoR tenant uses the first audience from the list (limitation in oauth2-helpers v5.50.0)
+- Audience values are configured separately per tenant in helm values files
+
+**Helm Configuration Example:**
+```yaml
+auth0:
+  entur:
+    internal:
+      url: https://internal.dev.entur.org/
+      audience: https://ror.api.dev.entur.io
+    partner:
+      url: https://partner.dev.entur.org/
+      audience: https://ror.api.dev.entur.io
+  ror:
+    url: https://ror-entur-dev.eu.auth0.com/
+    audience: https://ror.api.dev.entur.io
+```
+
+**Files Modified:**
+- `src/main/java/no/entur/nanna/nanna/config/OAuth2Config.java`
+- `helm/nanna/templates/configmap.yaml`
+- `helm/nanna/env/values-kub-ent-dev.yaml`
+- `helm/nanna/env/values-kub-ent-tst.yaml`
+- `helm/nanna/env/values-kub-ent-prd.yaml`
 understand 

--- a/helm/nanna/env/values-kub-ent-dev.yaml
+++ b/helm/nanna/env/values-kub-ent-dev.yaml
@@ -22,8 +22,10 @@ auth0:
   entur:
     internal:
       url: https://internal.dev.entur.org/
+      audience: https://ror.api.dev.entur.io
     partner:
       url: https://partner.dev.entur.org/
+      audience: https://ror.api.dev.entur.io,https://api.dev.entur.io,https://portal.dev.entur.org
 
 oauth2:
   client:

--- a/helm/nanna/env/values-kub-ent-prd.yaml
+++ b/helm/nanna/env/values-kub-ent-prd.yaml
@@ -22,8 +22,10 @@ auth0:
   entur:
     internal:
       url: https://internal.entur.org/
+      audience: https://ror.api.entur.io
     partner:
       url: https://partner.entur.org/
+      audience: https://ror.api.entur.io
 
 oauth2:
   client:

--- a/helm/nanna/env/values-kub-ent-tst.yaml
+++ b/helm/nanna/env/values-kub-ent-tst.yaml
@@ -22,8 +22,10 @@ auth0:
   entur:
     internal:
       url: https://internal.staging.entur.org/
+      audience: https://ror.api.staging.entur.io
     partner:
       url: https://partner.staging.entur.org/
+      audience: https://ror.api.staging.entur.io
 
 oauth2:
   client:

--- a/helm/nanna/templates/configmap.yaml
+++ b/helm/nanna/templates/configmap.yaml
@@ -29,11 +29,11 @@ data:
 
     # OAuth2 Resource Server for Entur Partner tenant
     nanna.oauth2.resourceserver.auth0.entur.partner.jwt.issuer-uri={{ .Values.auth0.entur.partner.url }}
-    nanna.oauth2.resourceserver.auth0.entur.partner.jwt.audience={{ .Values.auth0.ror.audience }}
+    nanna.oauth2.resourceserver.auth0.entur.partner.jwt.audience={{ .Values.auth0.entur.partner.audience }}
 
     # OAuth2 Resource Server for Entur internal tenant
     nanna.oauth2.resourceserver.auth0.entur.internal.jwt.issuer-uri={{ .Values.auth0.entur.internal.url }}
-    nanna.oauth2.resourceserver.auth0.entur.internal.jwt.audience={{ .Values.auth0.ror.audience }}
+    nanna.oauth2.resourceserver.auth0.entur.internal.jwt.audience={{ .Values.auth0.entur.internal.audience }}
 
     # OAuth2 Resource Server for RoR tenant
     nanna.oauth2.resourceserver.auth0.ror.jwt.issuer-uri={{ .Values.auth0.ror.url }}

--- a/src/main/java/no/entur/nanna/nanna/config/OAuth2Config.java
+++ b/src/main/java/no/entur/nanna/nanna/config/OAuth2Config.java
@@ -16,6 +16,9 @@
 
 package no.entur.nanna.nanna.config;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.entur.oauth2.AuthorizedWebClientBuilder;
 import org.entur.oauth2.multiissuer.MultiIssuerAuthenticationManagerResolver;
 import org.entur.oauth2.multiissuer.MultiIssuerAuthenticationManagerResolverBuilder;
@@ -37,19 +40,19 @@ public class OAuth2Config {
   public MultiIssuerAuthenticationManagerResolver multiIssuerAuthenticationManagerResolver(
     @Value(
       "${nanna.oauth2.resourceserver.auth0.entur.internal.jwt.audience:}"
-    ) String enturInternalAuth0Audience,
+    ) String enturInternalAuth0Audiences,
     @Value(
       "${nanna.oauth2.resourceserver.auth0.entur.internal.jwt.issuer-uri:}"
     ) String enturInternalAuth0Issuer,
     @Value(
       "${nanna.oauth2.resourceserver.auth0.entur.partner.jwt.audience:}"
-    ) String enturPartnerAuth0Audience,
+    ) String enturPartnerAuth0Audiences,
     @Value(
       "${nanna.oauth2.resourceserver.auth0.entur.partner.jwt.issuer-uri:}"
     ) String enturPartnerAuth0Issuer,
     @Value(
       "${nanna.oauth2.resourceserver.auth0.ror.jwt.audience:}"
-    ) String rorAuth0Audience,
+    ) String rorAuth0Audiences,
     @Value(
       "${nanna.oauth2.resourceserver.auth0.ror.jwt.issuer-uri:}"
     ) String rorAuth0Issuer,
@@ -59,13 +62,31 @@ public class OAuth2Config {
   ) {
     return new MultiIssuerAuthenticationManagerResolverBuilder()
       .withEnturInternalAuth0Issuer(enturInternalAuth0Issuer)
-      .withEnturInternalAuth0Audience(enturInternalAuth0Audience)
+      .withEnturInternalAuth0Audiences(
+        parseAudiences(enturInternalAuth0Audiences)
+      )
       .withEnturPartnerAuth0Issuer(enturPartnerAuth0Issuer)
-      .withEnturPartnerAuth0Audience(enturPartnerAuth0Audience)
+      .withEnturPartnerAuth0Audiences(
+        parseAudiences(enturPartnerAuth0Audiences)
+      )
       .withRorAuth0Issuer(rorAuth0Issuer)
-      .withRorAuth0Audience(rorAuth0Audience)
+      .withRorAuth0Audience(parseFirstAudience(rorAuth0Audiences))
       .withRorAuth0ClaimNamespace(rorAuth0ClaimNamespace)
       .build();
+  }
+
+  private List<String> parseAudiences(String audiences) {
+    if (audiences == null || audiences.trim().isEmpty()) {
+      return Collections.emptyList();
+    }
+    return Arrays.asList(audiences.split(","));
+  }
+
+  private String parseFirstAudience(String audiences) {
+    if (audiences == null || audiences.trim().isEmpty()) {
+      return "";
+    }
+    return audiences.split(",")[0].trim();
   }
 
   /**


### PR DESCRIPTION
## Summary
This PR refactors the OAuth2 configuration to support multiple audiences for better flexibility in multi-tenant environments, following the same pattern as the kilili project.

## Changes Made

### OAuth2Config.java
- Updated parameter names from singular (Audience) to plural (Audiences)
- Changed builder methods to use plural versions: `withEnturInternalAuth0Audiences()` and `withEnturPartnerAuth0Audiences()`
- Added `parseAudiences()` helper method to convert comma-separated audience strings to `List<String>`
- Added `parseFirstAudience()` helper for RoR tenant (which only supports single audience in oauth2-helpers v5.50.0)
- Added necessary imports for Arrays, Collections, and List

### Helm Configuration
- Updated configmap.yaml to use tenant-specific audience values instead of all using `auth0.ror.audience`
- Added separate `audience` configuration for each tenant in environment values files (dev/tst/prd)
- Configured Entur Partner dev environment with multiple audiences:
  - https://ror.api.dev.entur.io
  - https://api.dev.entur.io
  - https://portal.dev.entur.org

## Configuration Details

**Entur Internal and Partner tenants:** Support multiple comma-separated audiences
**RoR tenant:** Uses the first audience from the list (limitation in oauth2-helpers v5.50.0)

## Testing
- ✅ Build successful: `mvn clean install`
- ✅ No test configuration changes needed (tests use `@Profile("test")` which skips OAuth2 config)
- ✅ Backward compatible: Current single-audience configurations continue to work

## Impact
- Enables the application to accept tokens from multiple OAuth2 audiences
- Provides better flexibility for multi-tenant environments
- Maintains backward compatibility with existing configurations