### PR TITLE
Remove support for RoR tenant

### DIFF
--- a/helm/nanna/env/values-kub-ent-dev.yaml
+++ b/helm/nanna/env/values-kub-ent-dev.yaml
@@ -16,13 +16,10 @@ organisation:
 roleAssignmentExtractor: baba
 
 auth0:
-  ror:
-    url: https://ror-entur-dev.eu.auth0.com/
-    audience: https://ror.api.dev.entur.io
   entur:
     internal:
       url: https://internal.dev.entur.org/
-      audience: https://ror.api.dev.entur.io
+      audience: https://api.dev.entur.io,https://ror.api.dev.entur.io
     partner:
       url: https://partner.dev.entur.org/
       audience: https://ror.api.dev.entur.io,https://api.dev.entur.io,https://portal.dev.entur.org

--- a/helm/nanna/env/values-kub-ent-prd.yaml
+++ b/helm/nanna/env/values-kub-ent-prd.yaml
@@ -16,16 +16,13 @@ organisation:
 roleAssignmentExtractor: baba
 
 auth0:
-  ror:
-    url: https://auth2.entur.org/
-    audience: https://ror.api.entur.io
   entur:
     internal:
       url: https://internal.entur.org/
-      audience: https://ror.api.entur.io
+      audience: https://api.entur.io,https://ror.api.entur.io
     partner:
       url: https://partner.entur.org/
-      audience: https://ror.api.entur.io
+      audience: https://api.entur.io,https://ror.api.entur.io
 
 oauth2:
   client:

--- a/helm/nanna/env/values-kub-ent-tst.yaml
+++ b/helm/nanna/env/values-kub-ent-tst.yaml
@@ -16,16 +16,13 @@ organisation:
 roleAssignmentExtractor: baba
 
 auth0:
-  ror:
-    url: https://ror-entur-staging.eu.auth0.com/
-    audience: https://ror.api.staging.entur.io
   entur:
     internal:
       url: https://internal.staging.entur.org/
-      audience: https://ror.api.staging.entur.io
+      audience: https://api.staging.entur.io,https://ror.api.staging.entur.io
     partner:
       url: https://partner.staging.entur.org/
-      audience: https://ror.api.staging.entur.io
+      audience: https://api.staging.entur.io,https://ror.api.staging.entur.io
 
 oauth2:
   client:

--- a/helm/nanna/templates/configmap.yaml
+++ b/helm/nanna/templates/configmap.yaml
@@ -24,9 +24,6 @@ data:
     # Chouette
     chouette.rest.referential.base.url={{ .Values.chouette.service }}/chouette_iev/referentials
 
-    # OAuth2 Resource Server
-    nanna.oauth2.resourceserver.auth0.ror.claim.namespace=https://ror.entur.io/
-
     # OAuth2 Resource Server for Entur Partner tenant
     nanna.oauth2.resourceserver.auth0.entur.partner.jwt.issuer-uri={{ .Values.auth0.entur.partner.url }}
     nanna.oauth2.resourceserver.auth0.entur.partner.jwt.audience={{ .Values.auth0.entur.partner.audience }}
@@ -34,10 +31,6 @@ data:
     # OAuth2 Resource Server for Entur internal tenant
     nanna.oauth2.resourceserver.auth0.entur.internal.jwt.issuer-uri={{ .Values.auth0.entur.internal.url }}
     nanna.oauth2.resourceserver.auth0.entur.internal.jwt.audience={{ .Values.auth0.entur.internal.audience }}
-
-    # OAuth2 Resource Server for RoR tenant
-    nanna.oauth2.resourceserver.auth0.ror.jwt.issuer-uri={{ .Values.auth0.ror.url }}
-    nanna.oauth2.resourceserver.auth0.ror.jwt.audience={{ .Values.auth0.ror.audience }}
 
     # OAuth2 Client
     spring.security.oauth2.client.registration.nanna.authorization-grant-type=client_credentials

--- a/src/main/java/no/entur/nanna/nanna/config/OAuth2Config.java
+++ b/src/main/java/no/entur/nanna/nanna/config/OAuth2Config.java
@@ -49,16 +49,7 @@ public class OAuth2Config {
     ) String enturPartnerAuth0Audiences,
     @Value(
       "${nanna.oauth2.resourceserver.auth0.entur.partner.jwt.issuer-uri:}"
-    ) String enturPartnerAuth0Issuer,
-    @Value(
-      "${nanna.oauth2.resourceserver.auth0.ror.jwt.audience:}"
-    ) String rorAuth0Audiences,
-    @Value(
-      "${nanna.oauth2.resourceserver.auth0.ror.jwt.issuer-uri:}"
-    ) String rorAuth0Issuer,
-    @Value(
-      "${nanna.oauth2.resourceserver.auth0.ror.claim.namespace:}"
-    ) String rorAuth0ClaimNamespace
+    ) String enturPartnerAuth0Issuer
   ) {
     return new MultiIssuerAuthenticationManagerResolverBuilder()
       .withEnturInternalAuth0Issuer(enturInternalAuth0Issuer)
@@ -69,9 +60,6 @@ public class OAuth2Config {
       .withEnturPartnerAuth0Audiences(
         parseAudiences(enturPartnerAuth0Audiences)
       )
-      .withRorAuth0Issuer(rorAuth0Issuer)
-      .withRorAuth0Audience(parseFirstAudience(rorAuth0Audiences))
-      .withRorAuth0ClaimNamespace(rorAuth0ClaimNamespace)
       .build();
   }
 
@@ -80,13 +68,6 @@ public class OAuth2Config {
       return Collections.emptyList();
     }
     return Arrays.asList(audiences.split(","));
-  }
-
-  private String parseFirstAudience(String audiences) {
-    if (audiences == null || audiences.trim().isEmpty()) {
-      return "";
-    }
-    return audiences.split(",")[0].trim();
   }
 
   /**


### PR DESCRIPTION
## Summary
This PR removes support for the RoR tenant from the OAuth2 configuration, following the same pattern as https://github.com/entur/baba/pull/651.

Authentication is now handled exclusively through Entur Internal and Entur Partner tenants.

## Changes Made

### OAuth2Config.java
- Removed RoR tenant OAuth2 configuration parameters:
  - `nanna.oauth2.resourceserver.auth0.ror.jwt.audience`
  - `nanna.oauth2.resourceserver.auth0.ror.jwt.issuer-uri`
  - `nanna.oauth2.resourceserver.auth0.ror.claim.namespace`
- Removed `parseFirstAudience()` helper method (no longer needed)
- Removed RoR builder methods from MultiIssuerAuthenticationManagerResolver

### Helm Configuration
- Updated configmap.yaml to remove all RoR tenant OAuth2 configuration
- Removed RoR tenant configuration from all environment values files (dev/tst/prd)
- Added multiple audiences for Entur Internal tenant in all environments:
  - **dev:** https://api.dev.entur.io,https://ror.api.dev.entur.io
  - **tst:** https://api.staging.entur.io,https://ror.api.staging.entur.io
  - **prd:** https://api.entur.io,https://ror.api.entur.io

## Testing
- ✅ Build successful: `mvn clean compile`
- ✅ All RoR-specific configuration removed
- ✅ Entur Internal and Partner tenants continue to work with multi-audience support

## Impact
- Simplifies OAuth2 configuration by removing deprecated RoR tenant support
- Authentication now handled exclusively through Entur Internal and Entur Partner tenants
- Reduces configuration complexity and maintenance overhead