### PR TITLE
Upgrade to Spring Boot 4

### DIFF
--- a/helm/nanna/templates/configmap.yaml
+++ b/helm/nanna/templates/configmap.yaml
@@ -46,10 +46,10 @@ data:
     # Actuator
     management.server.port=9001
     management.endpoints.access.default=none
-    management.endpoint.info.enabled=true
-    management.endpoint.health.enabled=true
+    management.endpoint.info.access=unrestricted
+    management.endpoint.health.access=unrestricted
     management.endpoint.health.group.readiness.include=readinessState,db
-    management.endpoint.prometheus.enabled=true
+    management.endpoint.prometheus.access=unrestricted
     management.endpoints.web.exposure.include=info,health,prometheus
 
 kind: ConfigMap

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.entur.ror</groupId>
 		<artifactId>superpom</artifactId>
-		<version>5.3.0</version>
+		<version>6.5.0</version>
 	</parent>
 
 	<groupId>no.entur.nanna</groupId>
@@ -40,11 +40,11 @@
 
 	<properties>
 		<java.version>21</java.version>
-		<entur.helpers.version>5.50.0</entur.helpers.version>
+		<entur.helpers.version>7.2.0</entur.helpers.version>
 		<swagger-jersey2.version>2.2.52</swagger-jersey2.version>
 		<javax.jdo.jdo-api.version>3.2.1</javax.jdo.jdo-api.version>
 		<commons-io.version>2.22.0</commons-io.version>
-		<spring-cloud-gcp-dependencies.version>6.2.3</spring-cloud-gcp-dependencies.version>
+		<spring-cloud-gcp-dependencies.version>7.4.10</spring-cloud-gcp-dependencies.version>
 		<prettier-java.version>2.1.0</prettier-java.version>
 		<prettier-maven-plugin.version>0.22</prettier-maven-plugin.version>
 		<plugin.prettier.goal>write</plugin.prettier.goal>
@@ -93,6 +93,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<!-- WebClient auto-configuration is no longer part of the web starters in Boot 4 -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-webclient</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
@@ -171,6 +176,12 @@
 			<scope>runtime</scope>
 		</dependency>
 
+		<!-- Spring Boot 4 moved Flyway auto-configuration into its own module;
+		     without it the migrations are never run. -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-flyway</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-database-postgresql</artifactId>
@@ -191,12 +202,6 @@
 		<dependency>
 			<groupId>net.logstash.logback</groupId>
 			<artifactId>logstash-logback-encoder</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<!--Janino is required by Logback for conditional processing in logback.xml-->
-		<dependency>
-			<groupId>org.codehaus.janino</groupId>
-			<artifactId>janino</artifactId>
 			<scope>runtime</scope>
 		</dependency>
 

--- a/src/main/java/no/entur/nanna/nanna/App.java
+++ b/src/main/java/no/entur/nanna/nanna/App.java
@@ -3,7 +3,7 @@ package no.entur.nanna.nanna;
 import no.entur.nanna.nanna.provider.domain.Provider;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.data.jpa.convert.threeten.Jsr310JpaConverters;
 
 @SpringBootApplication

--- a/src/main/java/no/entur/nanna/nanna/config/OAuth2Config.java
+++ b/src/main/java/no/entur/nanna/nanna/config/OAuth2Config.java
@@ -23,7 +23,7 @@ import org.entur.oauth2.AuthorizedWebClientBuilder;
 import org.entur.oauth2.multiissuer.MultiIssuerAuthenticationManagerResolver;
 import org.entur.oauth2.multiissuer.MultiIssuerAuthenticationManagerResolverBuilder;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;

--- a/src/main/java/no/entur/nanna/nanna/security/oauth/NannaWebSecurityConfiguration.java
+++ b/src/main/java/no/entur/nanna/nanna/security/oauth/NannaWebSecurityConfiguration.java
@@ -12,7 +12,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -65,23 +64,15 @@ public class NannaWebSecurityConfiguration {
       .csrf(AbstractHttpConfigurer::disable)
       .authorizeHttpRequests(authz ->
         authz
-          .requestMatchers(
-            AntPathRequestMatcher.antMatcher("/services/providers/openapi.json")
-          )
+          .requestMatchers("/services/providers/openapi.json")
           .permitAll()
-          .requestMatchers(
-            AntPathRequestMatcher.antMatcher("/actuator/prometheus")
-          )
+          .requestMatchers("/actuator/prometheus")
           .permitAll()
-          .requestMatchers(AntPathRequestMatcher.antMatcher("/actuator/health"))
+          .requestMatchers("/actuator/health")
           .permitAll()
-          .requestMatchers(
-            AntPathRequestMatcher.antMatcher("/actuator/health/liveness")
-          )
+          .requestMatchers("/actuator/health/liveness")
           .permitAll()
-          .requestMatchers(
-            AntPathRequestMatcher.antMatcher("/actuator/health/readiness")
-          )
+          .requestMatchers("/actuator/health/readiness")
           .permitAll()
           .anyRequest()
           .authenticated()

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -16,7 +16,10 @@
   -->
 
 <configuration>
-    <if condition='property("env").contains("dev")'>
+    <condition class="ch.qos.logback.core.boolex.ExpressionPropertyCondition">
+        <expression>propertyContains("env", "dev")</expression>
+    </condition>
+    <if>
         <then>
             <include resource="org/springframework/boot/logging/logback/base.xml" />
         </then>

--- a/src/test/java/no/entur/nanna/nanna/NannaTestApp.java
+++ b/src/test/java/no/entur/nanna/nanna/NannaTestApp.java
@@ -18,7 +18,7 @@ package no.entur.nanna.nanna;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 

--- a/src/test/java/no/entur/nanna/nanna/security/oauth/NannaWebSecurityConfigurationTest.java
+++ b/src/test/java/no/entur/nanna/nanna/security/oauth/NannaWebSecurityConfigurationTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ *
+ */
+
+package no.entur.nanna.nanna.security.oauth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import jakarta.servlet.Filter;
+import org.entur.oauth2.multiissuer.MultiIssuerAuthenticationManagerResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Drives the production security chain built by {@link NannaWebSecurityConfiguration}.
+ * No Spring profile is activated on purpose: the configuration is {@code @Profile("!test")}
+ * and would be skipped under the "test" profile used by the rest of the suite.
+ */
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration(
+  classes = {
+    NannaWebSecurityConfiguration.class,
+    NannaWebSecurityConfigurationTest.SecurityChainDependencies.class,
+  }
+)
+class NannaWebSecurityConfigurationTest {
+
+  // NannaTestApp declares its own @ComponentScan, which drops Spring Boot's TypeExcludeFilter, so a
+  // stereotype-annotated static nested class here would be scanned into the Spring Boot contexts of
+  // the rest of the suite. Hence @Bean methods without @Configuration (lite mode) below, and a
+  // non-static controller, which component scanning skips as not independent.
+  static class SecurityChainDependencies {
+
+    @Bean
+    MultiIssuerAuthenticationManagerResolver multiIssuerAuthenticationManagerResolver() {
+      return Mockito.mock(MultiIssuerAuthenticationManagerResolver.class);
+    }
+
+    @Bean
+    ClientRegistrationRepository clientRegistrationRepository() {
+      return registrationId -> null;
+    }
+  }
+
+  @RestController
+  class AnyPathController {
+
+    @GetMapping("/**")
+    String reached() {
+      return "reached";
+    }
+  }
+
+  @Autowired
+  @Qualifier("springSecurityFilterChain")
+  private Filter springSecurityFilterChain;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc =
+      MockMvcBuilders
+        .standaloneSetup(new AnyPathController())
+        .addFilters(springSecurityFilterChain)
+        .build();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+    strings = {
+      "/services/providers/openapi.json",
+      "/actuator/prometheus",
+      "/actuator/health",
+      "/actuator/health/liveness",
+      "/actuator/health/readiness",
+    }
+  )
+  void publicPathIsReachableWithoutAuthentication(String path)
+    throws Exception {
+    assertEquals(
+      200,
+      status(path),
+      path + " must be permitted without a token"
+    );
+  }
+
+  // Near misses pin exact-match semantics: nothing here may be widened to /actuator/**.
+  @ParameterizedTest
+  @ValueSource(
+    strings = {
+      "/actuator/env",
+      "/actuator/health/liveness/extra",
+      "/services/providers/openapi.json/extra",
+      "/services/providers",
+    }
+  )
+  void otherPathRequiresAuthentication(String path) throws Exception {
+    assertEquals(401, status(path), path + " must require a token");
+  }
+
+  private int status(String path) throws Exception {
+    return mockMvc.perform(get(path)).andReturn().getResponse().getStatus();
+  }
+}


### PR DESCRIPTION
Boot 4 split Flyway auto-configuration into spring-boot-flyway and WebClient into spring-boot-webclient. Without the first, migrations silently never run; without the second there is no WebClient.Builder, which OAuth2Config and ChouetteReferentialRestClient both inject.

logback moves to the condition element, so janino is no longer needed.