### PR TITLE
jdk 25 and spring boot 4.1

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -10,16 +10,16 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
       - name: Copy maven settings
         run: |
           wget https://raw.githubusercontent.com/entur/ror-maven-settings/master/.m2/settings.xml -O .github/workflows/settings.xml
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v5.7.0
         with:
-          java-version: 21.0.6+10
+          java-version: 25.0.4
           distribution: liberica
       - name: Cache Maven dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@v6.1.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,15 +12,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v5.7.0
         with:
-          java-version: 21.0.7+9
+          java-version: 25.0.4
           distribution: liberica
       - name: Cache Maven dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@v6.1.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -51,6 +51,26 @@ jobs:
                   -Dsonar.projectName=${SONAR_PROJECT_NAME} \
                   -Dsonar.host.url=https://sonarcloud.io \
                   -Dsonar.token=${SONAR_TOKEN}
+  docker-smoke:
+    needs: [maven-verify]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/download-artifact@v8.0.1
+        with:
+          name: artifact
+          path: target
+      - run: docker build -t nanna:smoke .
+      # Nothing else in CI runs the image. Reaching Spring's startup line proves the JRE loaded the
+      # application bytecode; it then fails on config that only exists in the cluster, which is fine.
+      # A wrong class file version or an unusable base image never gets that far.
+      - run: |
+          timeout 180 docker run --rm -e SPRING_CLOUD_GCP_SQL_ENABLED=false nanna:smoke 2>&1 | tee smoke.log || true
+          grep -q "using Java" smoke.log
+
   docker-build:
     if: github.repository_owner == 'entur' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [maven-verify]
@@ -59,7 +79,7 @@ jobs:
       build_artifact_name: artifact
       build_artifact_path: target
   docker-push:
-    needs: [docker-build]
+    needs: [docker-build, docker-smoke]
     uses: entur/gha-docker/.github/workflows/push.yml@v1
 
   helm-lint:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file was created on 2025-11-25.
 **Nanna** is a **Provider Registry application** for Entur (Norwegian public transport) that manages provider information for the Ninkasi system.
 
 ### Tech Stack
-- **Java 21** with **Spring Boot** (web application)
+- **Java 25** with **Spring Boot** (web application)
 - **PostgreSQL** database with Flyway migrations
 - **Jersey** (JAX-RS) for REST APIs
 - **Hibernate/JPA** for ORM with spatial support

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM bellsoft/liberica-openjre-alpine:21.0.12-10 AS builder
+FROM bellsoft/liberica-openjre-alpine:25.0.4 AS builder
 WORKDIR /builder
 COPY target/*-SNAPSHOT.jar application.jar
 RUN java -Djarmode=tools  -jar application.jar extract --layers --destination extracted
 
-FROM bellsoft/liberica-openjre-alpine:21.0.12-10
+FROM bellsoft/liberica-openjre-alpine:25.0.4
 RUN apk update && apk upgrade && apk add --no-cache tini
 WORKDIR /deployments
 RUN addgroup appuser && adduser --disabled-password appuser --ingroup appuser

--- a/helm/nanna/templates/deployment.yaml
+++ b/helm/nanna/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           env:
             - name: JDK_JAVA_OPTIONS
               value: -server -Xmx500m -Xss512k -XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
-                -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -Dspring.config.location=/etc/application-config/application.properties
+                -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:+IgnoreUnrecognizedVMOptions --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Dspring.config.location=/etc/application-config/application.properties
                 -Dfile.encoding=UTF-8  {{- if .Values.monitoringEnabled }} -Dcom.sun.management.jmxremote.port=9999  -Dcom.sun.management.jmxremote.rmi.port=9998 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1
             {{- end }}
             - name: TZ

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.entur.ror</groupId>
 		<artifactId>superpom</artifactId>
-		<version>6.5.0</version>
+		<version>7.0.0</version>
 	</parent>
 
 	<groupId>no.entur.nanna</groupId>
@@ -39,7 +39,6 @@
 	</scm>
 
 	<properties>
-		<java.version>21</java.version>
 		<entur.helpers.version>7.2.0</entur.helpers.version>
 		<swagger-jersey2.version>2.2.52</swagger-jersey2.version>
 		<javax.jdo.jdo-api.version>3.2.1</javax.jdo.jdo-api.version>


### PR DESCRIPTION
The chart gains the JDK 25 native-access and Unsafe flags, guarded by IgnoreUnrecognizedVMOptions so the chart still boots if it ever meets a pre-JDK-24 image. New docker-smoke job starts the built image and gates docker-push; it disables the Cloud SQL autoconfiguration, which otherwise fails in prepareEnvironment before the app logs anything.